### PR TITLE
Modify Dofikerfile for convert Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
-FROM ruby:2.6.3
-ENV LANG C.UTF-8
-WORKDIR /tmp
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get update -qq && apt-get install -y \
-    build-essential \
-    nodejs && \
-    rm -rf /var/lib/apt/lists/* && \
-    gem install bundler
+FROM ruby:2.6.3-alpine
+ENV APP_ROOT /usr/src/app
 
-ADD Gemfile Gemfile
-ADD Gemfile.lock Gemfile.lock
-RUN bundle install
-
-RUN mkdir -p /usr/src/app 
-WORKDIR /usr/src/app
+WORKDIR $APP_ROOT
+RUN apk add --update --no-cache --virtual=build-dependencies \
+      build-base \
+      curl-dev \
+      linux-headers \
+      libxml2-dev \
+      libxslt-dev \
+      mysql-dev \
+      postgresql-dev \
+      ruby-dev \
+      sqlite-dev \
+      yaml-dev \
+      zlib-dev && \
+    apk add --update --no-cache \
+      libxslt	\
+      nodejs \
+      postgresql \
+      tzdata \
+      yaml && \
+    echo 'gem: --no-document' >> ~/.gemrc && \
+    cp ~/.gemrc /etc/gemrc && \
+    chmod uog+r /etc/gemrc
+COPY Gemfile $APP_ROOT
+COPY Gemfile.lock $APP_ROOT
+RUN bundle install && \
+    rm -rf ~/.gem && \
+    apk del build-dependencies
 
 EXPOSE 3000


### PR DESCRIPTION
Docker ImageのFROMをAlpine LinuxベースのDocker Imageに変更しました。
これにより、Pitari Appコンテナの容量が約1.08GBから460MBに削減されます。
これまで使用できていた「bash」は使えなくなります。代わりに「sh」を使って下さい。