### PR TITLE
Modify dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
-FROM ruby:2.6.3
-ENV LANG C.UTF-8
-WORKDIR /tmp
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get update -qq && apt-get install -y \
-    build-essential \
-    nodejs && \
-    rm -rf /var/lib/apt/lists/* && \
-    gem install bundler
+FROM ruby:2.6.3-alpine
+ENV APP_ROOT /usr/src/app
 
-ADD Gemfile Gemfile
-ADD Gemfile.lock Gemfile.lock
-RUN bundle install
-
-RUN mkdir -p /usr/src/app 
-WORKDIR /usr/src/app
+WORKDIR $APP_ROOT
+RUN apk add --update --no-cache --virtual=build-dependencies \
+      build-base \
+      curl-dev \
+      linux-headers \
+      libxml2-dev \
+      libxslt-dev \
+      mysql-dev \
+      postgresql-dev \
+      ruby-dev \
+      sqlite-dev \
+      yaml-dev \
+      zlib-dev && \
+    apk add --update --no-cache \
+      libxslt	\
+      nodejs \
+      postgresql \
+      tzdata \
+      yaml && \
+    echo 'gem: --no-document' >> ~/.gemrc && \
+    cp ~/.gemrc /etc/gemrc && \
+    chmod uog+r /etc/gemrc
+COPY Gemfile $APP_ROOT
+COPY Gemfile.lock $APP_ROOT
+RUN bundle install && \
+    rm -rf ~/.gem && \
+    apk del build-dependencies
 
 EXPOSE 3000

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,14 +50,14 @@ GEM
     autoprefixer-rails (9.5.1)
       execjs
     bindex (0.7.0)
-    bootsnap (1.4.3)
+    bootsnap (1.4.4)
       msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.3)
     byebug (11.0.1)
-    capybara (3.16.2)
+    capybara (3.18.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -65,8 +65,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
+    childprocess (1.0.1)
+      rake (< 13.0)
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
@@ -110,10 +110,10 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    msgpack (1.2.9)
+    msgpack (1.2.10)
     multi_json (1.13.1)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
     public_suffix (3.0.3)
@@ -163,8 +163,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.141.0)
-      childprocess (~> 0.5)
+    selenium-webdriver (3.142.0)
+      childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -228,4 +228,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.1
+   1.17.2


### PR DESCRIPTION
Docker ImageをAlpine Linuxベースに変更しました。
この変更でappコンテナの容量が1.08GB程度から460MB程度に削減されます。
![Screenshot from 2019-04-30 19-52-40](https://user-images.githubusercontent.com/31640715/56958826-70934480-6b86-11e9-9fe7-a30130431921.png)
Linux distributionの変更に伴い「bash」が利用できなくなります。今後は「sh」を使う必要があります。